### PR TITLE
fix(exception-logging): Adds Exception.ToString() to NewRelicLogItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This sink adds four additional properties:
 * `application` holds the value from `applicationName`
 * `level` is the actual log level of the event.
 * `stack_trace` holds the stack trace portion of an exception.
+* `exception` holds the `.toString()` of an exception.
 
 If `newrelic.linkingmetadata` property is present in an event, it will be unrolled into individual NewRelic properties used for "logs in context".
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,29 @@ If `newrelic.linkingmetadata` property is present in an event, it will be unroll
 PM> Install-Package Serilog.Sinks.NewRelic.Logs
 ```
 
+### JSON configuration
+
+It is possible to configure the sink using [Serilog.Settings.Configuration](https://github.com/serilog/serilog-settings-configuration) by specifying the license key and other desired parameters in `appsettings.json`:
+
+```
+{
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.NewRelic.Logs" ],
+    "WriteTo": [
+      {
+        "Name": "NewRelicLogs",
+        "Args": {
+          "applicationName": "NewRelicLogTestSample",
+          "licenseKey": "58e9892abd3f09d91b0db0d0e9e95628FFFFNRAL"
+          //... other parameters
+        }
+      }
+    ],
+    "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId", "WithNewRelicLogsInContext" ]
+  }
+}
+```
+
 ## Contributors
 
 This code is based on https://github.com/stanisls/serilog-sinks-newreliclogs

--- a/src/Serilog.Sinks.NewRelic.Logs/Sinks/NewRelicLogs/NewRelicLogPayload.cs
+++ b/src/Serilog.Sinks.NewRelic.Logs/Sinks/NewRelicLogs/NewRelicLogPayload.cs
@@ -40,6 +40,10 @@ namespace Serilog.Sinks.NewRelic.Logs
             this.Message = logEvent.RenderMessage(formatProvider);
             this.Attributes.Add("level", logEvent.Level.ToString());
             this.Attributes.Add("stack_trace", logEvent.Exception?.StackTrace ?? "");
+            if (logEvent.Exception != null) 
+            {
+                this.Attributes.Add("exception", logEvent.Exception.ToString() ?? "");
+            }
 
             foreach (var property in logEvent.Properties)
             {


### PR DESCRIPTION
![pyl1E9trnmwdW](https://user-images.githubusercontent.com/6044597/106577788-12577a80-653f-11eb-9c71-6f28d0c0594d.gif)


### Status

READY

### Whats?

Adds the "exception" item in `NewRelicLogItem.Attributes` which holds the `.ToString()` of the exception, so more information about the Exception will be included in the log entry (inner exceptions, message, exception type).

I haven't changed the `stack_trace` attribute as it still might be used and this PR should be a minor version increase. (1.0.2)


### Why?

More information about a thrown Exception is always welcome :)

### How?

Adds the "exception" item in `NewRelicLogItem.Attributes` which holds the `.ToString()`

### Attachments (if appropriate)

![image](https://user-images.githubusercontent.com/6044597/106577449-aaa12f80-653e-11eb-86d5-46c8165624ba.png)


### Definition of Done:
- [X] Increases API documentation
- [ ] Implements integration tests
- [ ] Implements unit tests
- [ ] Is there appropriate logging included?
- [ ] Does this add new dependencies?
- [ ] Does need add new version in changelog?
- [ ] Does need update readme, contributing, etc?
- [ ] Does need change in CI server?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.
