### PR TITLE
:arrow-up: [feature] Adds support on serilog-sinks-periodicbatching 3.0.0

### DIFF
--- a/Serilog.Sinks.NewRelic.Logs.sln
+++ b/Serilog.Sinks.NewRelic.Logs.sln
@@ -31,6 +31,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.NewRelic.Logs
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.NewRelic.Logs.Playground.NET461", "sample\Serilog.Sinks.NewRelic.Logs.Playground.NET461\Serilog.Sinks.NewRelic.Logs.Playground.NET461.csproj", "{21B9673F-0A6B-41E3-BFF1-3404A3318BDC}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sample", "sample", "{B1386F56-919D-4B51-A599-DA4C16947D3B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.NewRelic.Logs.Playground.NET6", "sample\Serilog.Sinks.NewRelic.Logs.Playground.NET6\Serilog.Sinks.NewRelic.Logs.Playground.NET6.csproj", "{BFCCA24A-E225-4017-8F81-CCD4193C2277}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -49,6 +53,10 @@ Global
 		{21B9673F-0A6B-41E3-BFF1-3404A3318BDC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{21B9673F-0A6B-41E3-BFF1-3404A3318BDC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{21B9673F-0A6B-41E3-BFF1-3404A3318BDC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BFCCA24A-E225-4017-8F81-CCD4193C2277}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BFCCA24A-E225-4017-8F81-CCD4193C2277}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BFCCA24A-E225-4017-8F81-CCD4193C2277}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BFCCA24A-E225-4017-8F81-CCD4193C2277}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -57,6 +65,7 @@ Global
 		{58888E6E-80BA-4F62-ADDF-A555B8CB6C4E} = {30EC5940-9B2D-485B-B854-F978C4B8BD5A}
 		{F891B038-B0A2-44E9-8F6A-6E14B5B39F95} = {30EC5940-9B2D-485B-B854-F978C4B8BD5A}
 		{A58D3608-75B5-47C4-A246-C93AC544178D} = {30EC5940-9B2D-485B-B854-F978C4B8BD5A}
+		{BFCCA24A-E225-4017-8F81-CCD4193C2277} = {B1386F56-919D-4B51-A599-DA4C16947D3B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C95D3C20-A9C4-43CC-89F5-CFA37A2C8D83}

--- a/sample/Serilog.Sinks.NewRelic.Logs.Playground.NET6/Program.cs
+++ b/sample/Serilog.Sinks.NewRelic.Logs.Playground.NET6/Program.cs
@@ -1,0 +1,118 @@
+﻿Console.WriteLine("Paste your NewRelic LicenseKey and press <enter>:");
+var licenseKey = Console.ReadLine();
+
+var logger = new LoggerConfiguration()
+    .MinimumLevel.Verbose()
+    .WriteTo.ColoredConsole(
+        outputTemplate: "{Timestamp:HH:mm:ss} ({ThreadId}) [{Level}] {Message}{NewLine}{Exception}")
+    .WriteTo.NewRelicLogs(
+        applicationName: "NewRelicLogsSinkDev",
+        licenseKey: licenseKey)
+    .Enrich.FromLogContext()
+    .Enrich.WithMachineName()
+    .Enrich.WithThreadId()
+    .Enrich.WithNewRelicLogsInContext()
+    .CreateLogger();
+
+logger
+    .ForContext("SampleTransaction", "trans1")
+    .Information("Message in a transaction");
+
+const string template = "This is a simple {Level} message {Val}";
+logger.Verbose(template, LogEventLevel.Verbose, (int)LogEventLevel.Verbose);
+logger.Debug(template, LogEventLevel.Debug, (int)LogEventLevel.Debug);
+logger.Information(template, LogEventLevel.Information, (int)LogEventLevel.Information);
+logger.Warning(template, LogEventLevel.Warning, (int)LogEventLevel.Warning);
+
+// Adding a custom transaction
+
+using (logger.BeginTimedOperation("Time a thread sleep for 2 seconds."))
+{
+    Thread.Sleep(1000);
+    using (logger.BeginTimedOperation("And inside we try a Task.Delay for 2 seconds."))
+    {
+        Task.Delay(2000).Wait();
+    }
+    Thread.Sleep(1000);
+}
+
+using (logger.BeginTimedOperation("Using a passed in identifier", "test-loop"))
+{
+    // ReSharper disable once NotAccessedVariable
+    var a = "";
+    for (var i = 0; i < 1000; i++)
+    {
+        a += "b";
+    }
+}
+
+// Exceed a limit
+using (logger.BeginTimedOperation("This should execute within 1 second.", null, LogEventLevel.Debug, TimeSpan.FromSeconds(1)))
+{
+    Thread.Sleep(1100);
+}
+
+// Gauge
+var queue = new Queue<int>();
+var gauge = logger.GaugeOperation("queue", "item(s)", () => queue.Count);
+
+gauge.Write();
+
+queue.Enqueue(20);
+
+gauge.Write();
+
+queue.Dequeue();
+
+gauge.Write();
+
+// Counter
+var counter = logger.CountOperation("counter", "operation(s)", true, LogEventLevel.Debug, resolution: 2);
+counter.Increment();
+counter.Increment();
+counter.Increment();
+counter.Decrement();
+
+// Throw Exception
+try
+{
+    throw new ApplicationException("This is an exception raised to test the New Relic API");
+}
+catch (Exception ex)
+{
+    logger.Error(ex, "Error whilst testing the Serilog.Sinks.NewRelic.Logs.Sample");
+    logger.Error("A templated test message notifying of an error. Value {val}", 1);
+
+    // adding complex object
+    LogContext.PushProperty("ComplexDictionary", GetComplexDictionary());
+    logger.Error("Test with complex object and dictionary");
+}
+
+logger.Dispose();
+
+Console.WriteLine("Press a key to exit.");
+Console.ReadKey(true);
+
+
+static IDictionary<string, object> GetComplexDictionary()
+    => new Dictionary<string, object>
+    {
+        { "property1", "WORKS!" },
+        { "property2", 123 },
+        { "property3", new Dictionary<string, object>
+        {
+            { "subproperty1", "blah blah" },
+            { "subproperty2", new Dictionary<string, object>
+            {
+                { "subsubproperty1", Guid.NewGuid() },
+                { "subproperty2", new Dictionary<string, object>
+                {
+                    { "subsubproperty1", DateTime.UtcNow },
+                    { "subsubproperty2", new Dictionary<string, object>
+                    {
+                        { "subsubsubproperty1", 10.500F }
+                    }}
+                }}
+            }}
+        }}
+    };

--- a/sample/Serilog.Sinks.NewRelic.Logs.Playground.NET6/Serilog.Sinks.NewRelic.Logs.Playground.NET6.csproj
+++ b/sample/Serilog.Sinks.NewRelic.Logs.Playground.NET6/Serilog.Sinks.NewRelic.Logs.Playground.NET6.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NewRelic.Agent.Api" Version="9.1.1" />
+    <PackageReference Include="NewRelic.LogEnrichers.Serilog" Version="1.0.1" />
+    <PackageReference Include="Serilog.Enrichers.Context" Version="4.2.0" />
+    <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.2" />
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
+    <PackageReference Include="SerilogMetrics" Version="2.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Serilog.Sinks.NewRelic.Logs\Serilog.Sinks.NewRelic.Logs.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sample/Serilog.Sinks.NewRelic.Logs.Playground.NET6/Usings.cs
+++ b/sample/Serilog.Sinks.NewRelic.Logs.Playground.NET6/Usings.cs
@@ -1,0 +1,8 @@
+global using NewRelic.LogEnrichers.Serilog;
+global using Serilog;
+global using Serilog.Context;
+global using Serilog.Events;
+global using System;
+global using System.Collections.Generic;
+global using System.Threading;
+global using System.Threading.Tasks;

--- a/src/Serilog.Sinks.NewRelic.Logs/Serilog.Sinks.NewRelic.Logs.csproj
+++ b/src/Serilog.Sinks.NewRelic.Logs/Serilog.Sinks.NewRelic.Logs.csproj
@@ -16,10 +16,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.0" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.0.0" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

### Status

READY

### Whats?

Fix the breaking change introduced by serilog-sinks-periodicbatching  3.0.0

### Why?

serilog-sinks-periodicbatching  3.0.0 introduced a breaking change on making the PeriodicBatchingSink class sealed.

### How?

Based on Serilog.Sinks.Seq the NewRelicLogsSink now implements the IBatchedLogEventSink interface.

### Attachments (if appropriate)

[The breaking change commit](https://github.com/serilog/serilog-sinks-periodicbatching/commit/734b03c0a9d0975d752cab9d4a7c869325fb3a02)

### Definition of Done:
- [ ] Increases API documentation
- [ ] Implements integration tests
- [ ] Implements unit tests
- [ ] Is there appropriate logging included?
- [ ] Does this add new dependencies?
- [x] Does need add new version in changelog?
- [ ] Does need update readme, contributing, etc?
- [ ] Does need change in CI server?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.
