### PR TITLE
[feature] Update `Serilog.Sinks.PeriodicBatching` to `3.1.0`

### DIFF
--- a/sample/Serilog.Sinks.NewRelic.Logs.Playground.NET461/Serilog.Sinks.NewRelic.Logs.Playground.NET461.csproj
+++ b/sample/Serilog.Sinks.NewRelic.Logs.Playground.NET461/Serilog.Sinks.NewRelic.Logs.Playground.NET461.csproj
@@ -60,8 +60,8 @@
     <Reference Include="Serilog.Sinks.Console, Version=4.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.Sinks.Console.4.0.0\lib\net45\Serilog.Sinks.Console.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog.Sinks.PeriodicBatching, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.Sinks.PeriodicBatching.2.3.0\lib\net45\Serilog.Sinks.PeriodicBatching.dll</HintPath>
+    <Reference Include="Serilog.Sinks.PeriodicBatching, Version=3.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.Sinks.PeriodicBatching.3.1.0\lib\net45\Serilog.Sinks.PeriodicBatching.dll</HintPath>
     </Reference>
     <Reference Include="SerilogMetrics, Version=2.1.0.0, Culture=neutral, PublicKeyToken=d4b150f150627b06, processorArchitecture=MSIL">
       <HintPath>..\..\packages\SerilogMetrics.2.1.0\lib\net46\SerilogMetrics.dll</HintPath>

--- a/sample/Serilog.Sinks.NewRelic.Logs.Playground.NET461/packages.config
+++ b/sample/Serilog.Sinks.NewRelic.Logs.Playground.NET461/packages.config
@@ -10,6 +10,6 @@
   <package id="Serilog.Enrichers.Thread" version="3.1.0" targetFramework="net461" />
   <package id="Serilog.Sinks.ColoredConsole" version="3.0.1" targetFramework="net461" />
   <package id="Serilog.Sinks.Console" version="4.0.0" targetFramework="net461" />
-  <package id="Serilog.Sinks.PeriodicBatching" version="2.3.0" targetFramework="net461" />
+  <package id="Serilog.Sinks.PeriodicBatching" version="3.1.0" targetFramework="net461" />
   <package id="SerilogMetrics" version="2.1.0" targetFramework="net461" />
 </packages>

--- a/src/Serilog.Sinks.NewRelic.Logs/Serilog.Sinks.NewRelic.Logs.csproj
+++ b/src/Serilog.Sinks.NewRelic.Logs/Serilog.Sinks.NewRelic.Logs.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.0" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

### Status

READY

### Whats?

- [x] Update `Serilog.Sinks.PeriodicBatching` to `3.1.0` 
- [x] Implement `IBatchedLogEventSink` instead of inheriting from `PeriodicBatchingSink` as recommended in [the README](https://github.com/serilog/serilog-sinks-periodicbatching/blob/dev/README.md).

### Why?

I'm troubleshooting an issue with dropped log messages, and having `PeriodicBatchingSink` up-to-date would allow me to debug more precisely, and report issues if I find any.

### How?

I updated the PeriodicBatchingSink implementation to follow their [current usage guidelines](https://github.com/serilog/serilog-sinks-periodicbatching/blob/dev/README.md).

### Attachments (if appropriate)

Add additional informations like screenshots, issue link, zendesk ticket link, jira task link, etc

### Definition of Done:
- [ ] Increases API documentation
- [ ] Implements integration tests
- [ ] Implements unit tests
- [ ] Is there appropriate logging included?
- [ ] Does this add new dependencies?
- [x] Does need add new version in changelog?
- [ ] Does need update readme, contributing, etc?
- [ ] Does need change in CI server?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.
